### PR TITLE
Deactivate unpermute preprocessor in sample config

### DIFF
--- a/nbgrader_config.py
+++ b/nbgrader_config.py
@@ -6,7 +6,7 @@ c.Autograde.sanitize_preprocessors = [
     'nbgrader.preprocessors.OverwriteKernelspec',
     'e2xgrader.preprocessors.OverwriteCells',
     'nbgrader.preprocessors.CheckCellMetadata',
-    'e2xgrader.preprocessors.UnpermuteTasks',
+    #'e2xgrader.preprocessors.UnpermuteTasks',
     'e2xgrader.preprocessors.Unscramble',
 ]
 


### PR DESCRIPTION
There are unresolved side effects when using unpermute, deactivate it in the sample config for now