### PR TITLE
Permute fix

### DIFF
--- a/e2xgrader/preprocessors/permutetasks.py
+++ b/e2xgrader/preprocessors/permutetasks.py
@@ -1,5 +1,8 @@
 import random
+from nbformat.v4 import new_notebook
+from copy import deepcopy
 from nbgrader.preprocessors import NbGraderPreprocessor
+from ..utils.nbgrader_cells import grade_id, get_tasks
 
 class PermuteTasks(NbGraderPreprocessor):
     
@@ -8,76 +11,36 @@ class PermuteTasks(NbGraderPreprocessor):
         if kw and 'seed' in kw:
             self.rand = random.Random(kw['seed'])
 
-    
-    def is_nbgrader_cell(self, cell):
-        return 'nbgrader' in cell.metadata
-    
-    def is_solution_cell(self, cell):
-        return self.is_nbgrader_cell(cell) and cell.metadata.nbgrader.solution
-    
-    def get_header(self, nb, task_ids):
-        header_idx = []
-        for i in range(len(nb.cells)):
-            cell = nb.cells[i]
-            if not self.is_nbgrader_cell(cell):
-                header_idx.append(i)
-            else:
-                grade_id = cell.metadata.nbgrader.grade_id
-                if not any(task_id in grade_id for task_id in task_ids):
-                    header_idx.append(i)
-        return header_idx
-    
-    def get_tasks(self, nb, task_ids):
-        associated = dict()
-        checked = dict()
-        
-        for task_id in task_ids:
-            checked[task_id] = False
-            associated[task_id] = []
-            for cell in nb.cells:
-                if self.is_nbgrader_cell(cell):
-                    grade_id = cell.metadata.nbgrader.grade_id
-                    if task_id in grade_id:
-                        associated[task_id].append(grade_id)
+    def permute(self, nb):
+        permuted_nb = new_notebook()
+        # Get indices of tasks
+        tasks = get_tasks(nb)
+        # Shuffle tasks
+        shuffled_tasks = deepcopy(tasks)
+        random.shuffle(shuffled_tasks)
+        # Record original order
+        original_order = []
 
-        groups = []
-        for i in range(len(task_ids)):
-            task_id = task_ids[i]
-            if checked[task_id]:
-                continue
-            new_group = set(associated[task_id])
-            for j in range(i+1, len(task_ids)):
-                task_idj = task_ids[j]
-                if any(t in associated[task_idj] for t in associated[task_id]):
-                    new_group.update(associated[task_idj])
-                    checked[task_idj] = True
-            groups.append(new_group)
+        cursor = 0
 
-        cell_groups = []
-        for group in groups:
-            cell_group = []
-            for i in range(len(nb.cells)):
-                cell = nb.cells[i]
-                if self.is_nbgrader_cell(cell) and cell.metadata.nbgrader.grade_id in group:
-                    cell_group.append(i)
-            cell_groups.append(cell_group)
-            
-        return cell_groups
+        for task in tasks:
+            # Add all cells between cursor and current task
+            for idx in range(cursor, task[0]):
+                permuted_nb.cells.append(nb.cells[idx])
+            # Get next task
+            next_task = shuffled_tasks.pop(0)
+            original_order.append(grade_id(nb.cells[task[0]]))
+            # Add cells of the next task
+            permuted_nb.cells.extend([nb.cells[idx] for idx in next_task])
+            # Set the cursor to the idx after the inserted task
+            cursor = task[-1] + 1
+
+        # Add remaining cells at the bottom of the notebook
+        permuted_nb.cells.extend([nb.cells[idx] for idx in range(cursor, len(nb.cells))])
+        # Save order
+        permuted_nb.metadata['original_order'] = original_order
+
+        return permuted_nb
     
     def preprocess(self, nb, resources):
-        # Extract ids of solution cells
-        task_ids = [cell.metadata.nbgrader.grade_id for cell in nb.cells
-                    if self.is_solution_cell(cell)]
-        # Get indices of header
-        header_idx = self.get_header(nb, task_ids)
-        # Get indices of tasks
-        tasks = self.get_tasks(nb, task_ids)
-        self.rand.shuffle(tasks)
-        ids = header_idx
-        for task in tasks:
-            ids.extend(task)
-            
-        cells = [nb.cells[i] for i in ids]
-        nb.cells = cells
-        nb.metadata['permutation'] = ids
-        return nb, resources
+        return self.permute(nb), resources

--- a/e2xgrader/preprocessors/unpermutetasks.py
+++ b/e2xgrader/preprocessors/unpermutetasks.py
@@ -1,10 +1,42 @@
 import random
+from nbformat.v4 import new_notebook
+from copy import deepcopy
 from nbgrader.preprocessors import NbGraderPreprocessor
+from ..utils.nbgrader_cells import grade_id, get_tasks
 
 class UnpermuteTasks(NbGraderPreprocessor):
+
+    def unpermute(self, nb):
+        unpermuted_nb = new_notebook()
+        # Get original order
+        original_order = nb.metadata.original_order
+        # Get indices of tasks
+        tasks = get_tasks(nb)
+
+        cursor = 0
+
+        for task in tasks:
+            # Add all cells between cursor and current task
+            for idx in range(cursor, task[0]):
+                unpermuted_nb.cells.append(nb.cells[idx])
+            # Get name and cells of next task in the original order
+            next_task_id = original_order.pop(0)
+            next_task = [task for task in tasks 
+                         if grade_id(nb.cells[task[0]]) == next_task_id][0]
+            # Add cells of the next task
+            unpermuted_nb.cells.extend([nb.cells[idx] for idx in next_task])
+            # Set the cursor to the idx after the inserted task
+            cursor = task[-1] + 1
+
+        # Add remaining cells at the bottom of the notebook
+        unpermuted_nb.cells.extend([nb.cells[idx] for idx in range(cursor, len(nb.cells))])
+
+        return unpermuted_nb
     
     def preprocess(self, nb, resources):
-        if 'permutation' in nb.metadata:
+        if 'original_order' not in nb.metadata:
+            return nb, resources
+
             perm = nb.metadata.permutation
             keys = sorted(range(len(perm)), key=perm.__getitem__)
             reorder_cells = [nb.cells[i] for i in keys]

--- a/e2xgrader/preprocessors/unpermutetasks.py
+++ b/e2xgrader/preprocessors/unpermutetasks.py
@@ -37,8 +37,8 @@ class UnpermuteTasks(NbGraderPreprocessor):
         if 'original_order' not in nb.metadata:
             return nb, resources
 
-            perm = nb.metadata.permutation
-            keys = sorted(range(len(perm)), key=perm.__getitem__)
-            reorder_cells = [nb.cells[i] for i in keys]
-            nb.cells = reorder_cells
+        perm = nb.metadata.permutation
+        keys = sorted(range(len(perm)), key=perm.__getitem__)
+        reorder_cells = [nb.cells[i] for i in keys]
+        nb.cells = reorder_cells
         return nb, resources

--- a/e2xgrader/utils/nbgrader_cells.py
+++ b/e2xgrader/utils/nbgrader_cells.py
@@ -18,9 +18,8 @@ def get_tasks(nb):
         checked[task_id] = False
         associated[task_id] = []
         for cell in nb.cells:
-            if is_nbgrader_cell(cell):
-                if task_id in grade_id(cell):
-                    associated[task_id].append(grade_id(cell))
+            if is_nbgrader_cell(cell) and task_id in grade_id(cell):
+                associated[task_id].append(grade_id(cell))
 
     groups = []
     for i in range(len(task_ids)):

--- a/e2xgrader/utils/nbgrader_cells.py
+++ b/e2xgrader/utils/nbgrader_cells.py
@@ -1,0 +1,47 @@
+def is_nbgrader_cell(cell):
+    return 'nbgrader' in cell.metadata
+
+def is_solution_cell(cell):
+    return is_nbgrader_cell(cell) and cell.metadata.nbgrader.solution
+
+def grade_id(cell):
+    if is_nbgrader_cell(cell):
+        return cell.metadata.nbgrader.grade_id
+
+def get_tasks(nb):
+    task_ids = [grade_id(cell) for cell in nb.cells 
+                if is_solution_cell(cell)]
+    associated = dict()
+    checked = dict()
+
+    for task_id in task_ids:
+        checked[task_id] = False
+        associated[task_id] = []
+        for cell in nb.cells:
+            if is_nbgrader_cell(cell):
+                if task_id in grade_id(cell):
+                    associated[task_id].append(grade_id(cell))
+
+    groups = []
+    for i in range(len(task_ids)):
+        task_id = task_ids[i]
+        if checked[task_id]:
+            continue
+        new_group = set(associated[task_id])
+        for j in range(i+1, len(task_ids)):
+            task_idj = task_ids[j]
+            if any(t in associated[task_idj] for t in associated[task_id]):
+                new_group.update(associated[task_idj])
+                checked[task_idj] = True
+        groups.append(new_group)
+
+    cell_groups = []
+    for group in groups:
+        cell_group = []
+        for i in range(len(nb.cells)):
+            cell = nb.cells[i]
+            if is_nbgrader_cell(cell) and grade_id(cell) in group:
+                cell_group.append(i)
+        cell_groups.append(cell_group)
+
+    return cell_groups


### PR DESCRIPTION
Permuting the exam now works the following way:

Identify all solution cells and associated cells to get a list of tasks. Swap the order of the tasks while keeping the order and position of the remaining cells intact.

Reverting the permutation works accordingly.
