### PR TITLE
Fix id validation error for old notebooks

### DIFF
--- a/e2xgrader/exchange/utils.py
+++ b/e2xgrader/exchange/utils.py
@@ -27,9 +27,8 @@ def append_alert_cell(nb, text, msg, cell_id):
 
     # When using notebooks with version <= 4.4 and nbformat v4.5
     # delete the new id attribute to prevent validation errors
-    if (nb.nbformat == 4 and nb.nbformat_minor <= 4):
-        if 'id' in alert_cell:
-            del alert_cell['id']
+    if nb.nbformat == 4 and nb.nbformat_minor <= 4 and 'id' in alert_cell:
+        del alert_cell['id']
 
     target_idx = -1
     for idx, cell in enumerate(nb.cells):

--- a/e2xgrader/exchange/utils.py
+++ b/e2xgrader/exchange/utils.py
@@ -24,6 +24,13 @@ def append_alert_cell(nb, text, msg, cell_id):
         'editable': False,
         'deletable': False
     }
+
+    # When using notebooks with version <= 4.4 and nbformat v4.5
+    # delete the new id attribute to prevent validation errors
+    if (nb.nbformat == 4 and nb.nbformat_minor <= 4):
+        if 'id' in alert_cell:
+            del alert_cell['id']
+
     target_idx = -1
     for idx, cell in enumerate(nb.cells):
         if has_name(cell, cell_id):


### PR DESCRIPTION
Nbformat introduced a new id for cells in version 4.5. When adding new markdown cells to older notebooks it can cause validation errors. Fixed the function ```append_alert_cell``` to delete this id if the notebook format is < 4.5