### PR TITLE
[WIP] change personalized outbound dir tree

### DIFF
--- a/e2xgrader/exchange/exchange.py
+++ b/e2xgrader/exchange/exchange.py
@@ -38,8 +38,9 @@ class E2xExchange(Exchange):
     def __init__(self, coursedir=None, authenticator=None, **kwargs):
         super().__init__(coursedir=coursedir, authenticator=authenticator, **kwargs)
 
+        # if personalized-outbound: exchange/personalized-outbound/<username>/<assignment_id>
         if self.personalized_outbound:
-            self.outbound_directory = 'personalized-outbound'
+            self.outbound_directory = os.path.join("personalized-outbound", os.getenv('JUPYTERHUB_USER'))
 
         if self.personalized_inbound:
             self.inbound_directory = 'personalized-inbound'

--- a/e2xgrader/exchange/exchange.py
+++ b/e2xgrader/exchange/exchange.py
@@ -38,9 +38,8 @@ class E2xExchange(Exchange):
     def __init__(self, coursedir=None, authenticator=None, **kwargs):
         super().__init__(coursedir=coursedir, authenticator=authenticator, **kwargs)
 
-        # if personalized-outbound: exchange/personalized-outbound/<username>/<assignment_id>
         if self.personalized_outbound:
-            self.outbound_directory = os.path.join("personalized-outbound", os.getenv('JUPYTERHUB_USER'))
+            self.outbound_directory = "personalized-outbound"
 
         if self.personalized_inbound:
             self.inbound_directory = 'personalized-inbound'

--- a/e2xgrader/exchange/release_assignment.py
+++ b/e2xgrader/exchange/release_assignment.py
@@ -21,7 +21,10 @@ class E2xExchangeReleaseAssignment(E2xExchange, ExchangeReleaseAssignment):
         self.course_path = os.path.join(self.root, self.coursedir.course_id)
         self.outbound_path = os.path.join(self.course_path, self.outbound_directory)
         self.inbound_path = os.path.join(self.course_path, self.inbound_directory)
-        self.dest_path = os.path.join(self.outbound_path, self.coursedir.assignment_id)
+        if self.personalized_outbound:
+            self.dest_path = os.path.join(self.outbound_path)
+        else:
+            self.dest_path = os.path.join(self.outbound_path, self.coursedir.assignment_id)
         # 0755
         # groupshared: +2040
         self.ensure_directory(
@@ -46,7 +49,7 @@ class E2xExchangeReleaseAssignment(E2xExchange, ExchangeReleaseAssignment):
 
     def copy_files(self):
         if os.path.isdir(self.dest_path):
-            if self.force:
+            if self.force or self.personalized_outbound:
                 self.log.info("Overwriting files: {} {}".format(
                     self.coursedir.course_id, self.coursedir.assignment_id
                 ))


### PR DESCRIPTION
Change `personalized-outbound` dir such that spawner does not have to know the assignment name to mount the outbound to user's container.

The directory structure under release directory should follow:
```
── release
│   └── <assignment_id>
│       └── <username>
│           └── <assignment_id>
                   └── test.ipynb
```

```
── exchange/<course_id>/personalized-outbound
│   └── <username>
│       └── <assignment_id>
│           └── test.ipynb
```

Note: this only works with a containerized jupyter notebook

Fixes #38 