### PR TITLE
[WIP] Fix personalized outbound

### DIFF
--- a/e2xgrader/exchange/release_assignment.py
+++ b/e2xgrader/exchange/release_assignment.py
@@ -26,7 +26,7 @@ class E2xExchangeReleaseAssignment(E2xExchange, ExchangeReleaseAssignment):
         self.course_path = os.path.join(self.root, self.coursedir.course_id)
         self.outbound_path = os.path.join(self.course_path, self.outbound_directory)
         self.inbound_path = os.path.join(self.course_path, self.inbound_directory)
-        self.dest_path = os.path.join(self.outbound_path, self.coursedir.assignment_id)
+
         # 0755
         # groupshared: +2040
         self.ensure_directory(
@@ -40,19 +40,46 @@ class E2xExchangeReleaseAssignment(E2xExchange, ExchangeReleaseAssignment):
             | S_IXOTH
             | ((S_ISGID | S_IWGRP) if self.coursedir.groupshared else 0),
         )
-        # 0755
-        # groupshared: +2040
-        self.ensure_directory(
-            self.outbound_path,
-            S_IRUSR
-            | S_IWUSR
-            | S_IXUSR
-            | S_IRGRP
-            | S_IXGRP
-            | S_IROTH
-            | S_IXOTH
-            | ((S_ISGID | S_IWGRP) if self.coursedir.groupshared else 0),
-        )
+
+        if self.personalized_outbound:
+            # the dest path is <exchange_root>/personalized-outbound/<username>/<assignment_id>
+            # <username> is created by either grader via formgrader or student during spawning
+            # <username> here is deterministic and has to be in the release directory
+            self.dest_path = self.outbound_path
+
+            # Make assignment directory writable so that spawner can create it (used only in k8s)
+            # 0777
+            os.chmod(
+                self.dest_path,
+                (
+                    S_IRUSR
+                    | S_IWUSR
+                    | S_IXUSR
+                    | S_IRGRP
+                    | S_IWGRP
+                    | S_IXGRP
+                    | S_IROTH
+                    | S_IWOTH
+                    | S_IXOTH
+                ),
+            )
+        else:
+            self.dest_path = os.path.join(self.outbound_path, self.coursedir.assignment_id)
+
+            # 0755
+            # groupshared: +2040
+            self.ensure_directory(
+                self.outbound_path,
+                S_IRUSR
+                | S_IWUSR
+                | S_IXUSR
+                | S_IRGRP
+                | S_IXGRP
+                | S_IROTH
+                | S_IXOTH
+                | ((S_ISGID | S_IWGRP) if self.coursedir.groupshared else 0),
+            )
+
         # 0733 with set GID so student submission will have the instructors group
         # groupshared: +0040
         self.ensure_directory(
@@ -69,13 +96,32 @@ class E2xExchangeReleaseAssignment(E2xExchange, ExchangeReleaseAssignment):
         )
 
     def copy_files(self):
-        if os.path.isdir(self.dest_path):
-            if self.force:
-                self.log.info(
-                    "Overwriting files: {} {}".format(
-                        self.coursedir.course_id, self.coursedir.assignment_id
+        if self.personalized_outbound:
+            # check available users under course_path/<assignmet_dir>/<username>
+            user_list = [user for user in os.listdir(self.src_path) \
+                         if os.path.isdir(os.path.join(self.src_path, user)) \
+                         and user != self.coursedir.assignment_id]
+            for user in user_list:
+                released_user_assignment = os.path.join(self.dest_path, user, self.coursedir.assignment_id)
+                if os.path.isdir(released_user_assignment):
+                    shutil.rmtree(released_user_assignment)
+
+                src_assignment = os.path.join(self.src_path, user)
+                if os.path.isdir(src_assignment):
+                    self.log.info(f"Source: {src_assignment}")
+                    self.log.info(f"Destination: {released_user_assignment}")
+                    self.do_copy(src_assignment, released_user_assignment)
+                    self.set_released_assignment_perm(released_user_assignment)
+                else:
+                    self.log.info(f"Src assignment not found: {src_assignment}")
+        else:
+            if os.path.isdir(self.dest_path):
+                if self.force:
+                    self.log.info(
+                        "Overwriting files: {} {}".format(
+                            self.coursedir.course_id, self.coursedir.assignment_id
+                        )
                     )
-                )
                 shutil.rmtree(self.dest_path)
             else:
                 self.fail(
@@ -83,11 +129,19 @@ class E2xExchangeReleaseAssignment(E2xExchange, ExchangeReleaseAssignment):
                         self.coursedir.course_id, self.coursedir.assignment_id
                     )
                 )
-        self.log.info("Source: {}".format(self.src_path))
-        self.log.info("Destination: {}".format(self.dest_path))
-        self.do_copy(self.src_path, self.dest_path)
+            self.log.info(f"Source: {self.src_path}")
+            self.log.info(f"Destination: {self.dest_path}")
+            self.do_copy(self.src_path, self.dest_path)
+            self.set_released_assignment_perm(self.dest_path)
+            self.log.info(
+                "Released as: {} {}".format(
+                    self.coursedir.course_id, self.coursedir.assignment_id
+                )
+            )
+
+    def set_released_assignment_perm(self, path):
         self.set_perms(
-            self.dest_path,
+            path,
             fileperms=(
                 S_IRUSR
                 | S_IWUSR
@@ -107,24 +161,3 @@ class E2xExchangeReleaseAssignment(E2xExchange, ExchangeReleaseAssignment):
             ),
         )
 
-        if self.personalized_outbound:
-            # Make assignment directory writable so that spawner can create it (K8s)
-            os.chmod(
-                self.dest_path,
-                (
-                    S_IRUSR
-                    | S_IWUSR
-                    | S_IXUSR
-                    | S_IRGRP
-                    | S_IWGRP
-                    | S_IXGRP
-                    | S_IROTH
-                    | S_IWOTH
-                    | S_IXOTH
-                ),
-            )
-        self.log.info(
-            "Released as: {} {}".format(
-                self.coursedir.course_id, self.coursedir.assignment_id
-            )
-        )

--- a/e2xgrader/exchange/release_assignment.py
+++ b/e2xgrader/exchange/release_assignment.py
@@ -102,16 +102,17 @@ class E2xExchangeReleaseAssignment(E2xExchange, ExchangeReleaseAssignment):
                          if os.path.isdir(os.path.join(self.src_path, user)) \
                          and user != self.coursedir.assignment_id]
             for user in user_list:
-                released_user_assignment = os.path.join(self.dest_path, user, self.coursedir.assignment_id)
+                released_assignment_root = os.path.join(self.dest_path, user)
+                released_user_assignment = os.path.join(released_assignment_root, self.coursedir.assignment_id)
                 if os.path.isdir(released_user_assignment):
                     shutil.rmtree(released_user_assignment)
 
-                src_assignment = os.path.join(self.src_path, user)
+                src_assignment = os.path.join(self.src_path, user, self.coursedir.assignment_id)
                 if os.path.isdir(src_assignment):
                     self.log.info(f"Source: {src_assignment}")
                     self.log.info(f"Destination: {released_user_assignment}")
                     self.do_copy(src_assignment, released_user_assignment)
-                    self.set_released_assignment_perm(released_user_assignment)
+                    self.set_released_assignment_perm(released_assignment_root)
                 else:
                     self.log.info(f"Src assignment not found: {src_assignment}")
         else:
@@ -122,13 +123,14 @@ class E2xExchangeReleaseAssignment(E2xExchange, ExchangeReleaseAssignment):
                             self.coursedir.course_id, self.coursedir.assignment_id
                         )
                     )
-                shutil.rmtree(self.dest_path)
-            else:
-                self.fail(
-                    "Destination already exists, add --force to overwrite: {} {}".format(
-                        self.coursedir.course_id, self.coursedir.assignment_id
+                    shutil.rmtree(self.dest_path)
+                else:
+                    self.fail(
+                        "Destination already exists, add --force to overwrite: {} {}".format(
+                            self.coursedir.course_id, self.coursedir.assignment_id
+                        )
                     )
-                )
+
             self.log.info(f"Source: {self.src_path}")
             self.log.info(f"Destination: {self.dest_path}")
             self.do_copy(self.src_path, self.dest_path)


### PR DESCRIPTION
There were two problems encountered during the last exams if personalized-outbound is used:
* The server is set up in such a way that the student cannot login when the personalized outbound is not released. This is bad since it's sometimes it's required for the students to log in first but exams are not released yet, they will be released when all students are present.
* Students can log in but the spawner will create a dir in the outbound dir which is not readable by graders (due to different linux UID), as a result graders cannot release the assignments

Solution in this PR
* Change the dir structure of personalized-outbound, instead of `personalized-outbound/<assignment_id>/<student_id>` to `personalized-outbound/<student_id>/<assignment_id>`. With this structure:
  * Either spawner or graders can have `rwx` access to `personalized-outbound/<student_id>`
  * This will follow personalized-inbound and personalized-feedback dir structure
  
  