### PR TITLE
Make sure keyboard manager is disabled on pdf cell

### DIFF
--- a/e2xgrader/nbextensions/src/common/extra_cells/extended_cell/extended_cell.js
+++ b/e2xgrader/nbextensions/src/common/extra_cells/extended_cell/extended_cell.js
@@ -48,6 +48,7 @@ define([
                 .addClass('e2x_unrender')
                 .click(function() {
                     that.cell.unrender_force();
+                    that.cell.keyboard_manager.enable();
                 }).append('Edit cell'));
             html.append(container);
         }

--- a/e2xgrader/nbextensions/src/common/extra_cells/extended_cell/pdf_cell.js
+++ b/e2xgrader/nbextensions/src/common/extra_cells/extended_cell/pdf_cell.js
@@ -17,6 +17,7 @@ define([
         render() {
             this.cell.unsafe_render();
             this.render_grader_settings();
+            this.cell.keyboard_manager.disable();
         }
 
     }


### PR DESCRIPTION
We want to put arbitrary html elements into the PDF/HTML cell. For this the keyboard_manager should be disabled when the cell is rendered.