### PR TITLE
Fix mathjax URL

### DIFF
--- a/e2xgrader/server_extensions/formgrader/handlers.py
+++ b/e2xgrader/server_extensions/formgrader/handlers.py
@@ -257,7 +257,7 @@ class SubmissionHandler(BaseHandler):
             "index": ix,
             "total": len(indices),
             "base_url": self.base_url,
-            "mathjax_url": self.mathjax_url,
+            "my_mathjax_url": self.base_url + "/" + self.mathjax_url,
             "student": student_id,
             "last_name": submission.student.last_name,
             "first_name": submission.student.first_name,

--- a/e2xgrader/server_extensions/formgrader/templates/formgrade/index.html.j2
+++ b/e2xgrader/server_extensions/formgrader/templates/formgrade/index.html.j2
@@ -15,7 +15,7 @@
 
 
 <!-- Loading mathjax macro -->
-{{ mathjax( resources.mathjax_url + '/' + resources.mathjax_url + '?config=TeX-AMS-MML_HTMLorMML-full') }}
+{{ mathjax( resources.my_mathjax_url + '?config=TeX-AMS-MML_HTMLorMML-full') }}
 
 <link rel="stylesheet" href="{{ resources.base_url }}/formgrader/static/css/formgrade.css" />
 <style type="text/css">


### PR DESCRIPTION
The mathjax URL needs to be specified including the base_url to work. See the corresponding [nbgrader commit](https://github.com/jupyter/nbgrader/commit/ce3d756efafa0802235abfcad78c28bc9ab9b859)