### PR TITLE
Add option to only grade certain cells

### DIFF
--- a/e2xgrader/preprocessors/saveautogrades.py
+++ b/e2xgrader/preprocessors/saveautogrades.py
@@ -1,11 +1,16 @@
+from textwrap import dedent
+from typing import Tuple
+
 from nbconvert.exporters.exporter import ResourcesDict
 from nbformat.notebooknode import NotebookNode
+from nbgrader.api import Gradebook
 from nbgrader.preprocessors import SaveAutoGrades as NbgraderSaveAutoGrades
 from nbgrader.utils import determine_grade
-from traitlets import Dict, Instance, Unicode
+from traitlets import Dict, Instance, List, TraitError, Unicode, validate
 
 from ..graders import BaseGrader, CodeGrader, MultipleChoiceGrader, SingleChoiceGrader
 from ..utils.extra_cells import is_extra_cell
+from ..utils.nbgrader_cells import grade_id
 
 
 class SaveAutoGrades(NbgraderSaveAutoGrades):
@@ -19,6 +24,27 @@ class SaveAutoGrades(NbgraderSaveAutoGrades):
             "multiplechoice": MultipleChoiceGrader(),
         },
     ).tag(config=True)
+
+    cells = List(
+        [],
+        help=dedent(
+            """
+            List of cells to save the autogrades for. If this is empty all cells will be saved.
+            """
+        ),
+    ).tag(config=True)
+
+    @validate("cells")
+    def _validate_cells(self, proposal):
+        value = proposal["value"]
+        if len(value) == 1:
+            elem = value[0].strip()
+            if elem.startswith("[") and elem.endswith("]"):
+                elem = elem[1:-1]
+            value = [v.strip() for v in elem.split(",")]
+        if not isinstance(value, list):
+            raise TraitError("cells must be a list")
+        return value
 
     def cell_type(self, cell: NotebookNode):
         if is_extra_cell(cell):
@@ -60,3 +86,28 @@ class SaveAutoGrades(NbgraderSaveAutoGrades):
             grade.needs_manual_grade = False
 
         self.gradebook.db.commit()
+
+    def preprocess(
+        self, nb: NotebookNode, resources: ResourcesDict
+    ) -> Tuple[NotebookNode, ResourcesDict]:
+        # pull information from the resources
+        self.notebook_id = resources["nbgrader"]["notebook"]
+        self.assignment_id = resources["nbgrader"]["assignment"]
+        self.student_id = resources["nbgrader"]["student"]
+        self.db_url = resources["nbgrader"]["db_url"]
+
+        # connect to the database
+        self.gradebook = Gradebook(self.db_url)
+
+        with self.gradebook:
+            # process the cells
+            nb, resources = super(SaveAutoGrades, self).preprocess(nb, resources)
+
+        return nb, resources
+
+    def preprocess_cell(
+        self, cell: NotebookNode, resources: ResourcesDict, cell_index: int
+    ) -> Tuple[NotebookNode, ResourcesDict]:
+        if len(self.cells) == 0 or grade_id(cell) in self.cells:
+            return super().preprocess_cell(cell, resources, cell_index)
+        return cell, resources


### PR DESCRIPTION
Add an option to grade only certain cells during autograding.

Use case: You autograde a notebook and do some manual grading. You realize one of your test cases needs some work. You change it and re run autograding. Now all grades will be updated.
With this option you can just update the grades for cells you changed

``nbgrader autograde Assignment_01 --SaveAutoGrades.cells=Cell_1,Cell_2,Cell_3`` This will only save the grades for cells ``Cell_1``, ``Cell_2`` and ``Cell_3``