### PR TITLE
Make sure preset path exists

### DIFF
--- a/e2xgrader/models/presetmodel.py
+++ b/e2xgrader/models/presetmodel.py
@@ -30,6 +30,8 @@ class PresetModel(BaseModel):
 
     def list_presets(self, preset_path):
         presets = []
+        if not os.path.exists(preset_path):
+            return presets
         for item in os.listdir(preset_path):
             if ".ipynb_checkpoints" in item:
                 continue

--- a/e2xgrader/tests/models/test_presetmodel.py
+++ b/e2xgrader/tests/models/test_presetmodel.py
@@ -68,6 +68,9 @@ class TestPresetModel(unittest.TestCase):
         assert len(self.model.list_template_presets()) == 1
         assert "MyPreset" in self.model.list_template_presets()
 
+    def test_non_existing_preset_path(self):
+        assert len(self.model.list_presets("/this/is/not/a/valid/path")) == 0
+
     def test_custom_task_preset_path(self):
         nbformat.write(
             nbformat.v4.new_notebook(), pjoin(self.tmp_dir.name, "MyPreset.ipynb")


### PR DESCRIPTION
When a non existing path was given to the preset model, the authoring frontend broke. 
Checking if the path exists fixes this.