### PR TITLE
Change addAssignment to setAssignment

### DIFF
--- a/packages/cells/src/utils/attachment-view.js
+++ b/packages/cells/src/utils/attachment-view.js
@@ -77,7 +77,7 @@ class Webcam {
               );
             let dataUrl = tmpCanvas[0].toDataURL("image/png");
             let key = that.model.getName("webcam", "png");
-            that.model.addAttachment(key, dataUrl);
+            that.model.setAttachment(key, dataUrl);
           },
         },
         Cancel: {},


### PR DESCRIPTION
Webcam upload was using the deprecated function ``addAttachment`` that has been renamed to ``setAttachment``