### PR TITLE
Make sure annotation area is on top of math

### DIFF
--- a/e2xgrader/server_extensions/grader/apps/formgrader/templates/formgrade/index.html.j2
+++ b/e2xgrader/server_extensions/grader/apps/formgrader/templates/formgrade/index.html.j2
@@ -62,6 +62,7 @@
     height: 100%;
     left: 0;
     top: 0;
+    z-index: 500;
 
   }
 


### PR DESCRIPTION
When annotating student answers containing math, the math was on top of the annotation area. This made it impossible to draw directly on math.