### PR TITLE
Make pip installable

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include e2xgrader/static *
+

--- a/e2xgrader/exporters/exporter.py
+++ b/e2xgrader/exporters/exporter.py
@@ -55,12 +55,16 @@ class E2xExporter(HTMLExporter):
     @property
     def template_paths(self):
         return super()._template_paths() + [
-            os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "server_extensions",
-                "formgrader",
-                "templates",
+            os.path.abspath(
+                os.path.join(
+                    os.path.dirname(__file__),
+                    "..",
+                    "server_extensions",
+                    "grader",
+                    "apps",
+                    "formgrader",
+                    "templates",
+                )
             )
         ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ classifiers=[
 ]
 dependencies = [
     "nbgrader==0.7.1",
+    "jupyter-core<4.11.2",
+    "jupyter-client<7.4",
+    "jupyter-server<1.20",
+    "nbconvert>=6.5",
+    "notebook>=6,<6.5",
     "beautifulsoup4",
     "pandas"
 ]


### PR DESCRIPTION
This PR fixes the requirements in the pyproject.toml. It seems that newer versions of jupyter client, server and core mess up the template paths 