### PR TITLE
Add isort to ruff and ignore unused imports in init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,5 @@ search = '"@e2xgrader/[\w-]+": "{current_version}'
 [tool.ruff]
 line-length = 100
 exclude = ["nbgrader_config.py"]
+ignore-init-module-imports = true
+select = ["F", "E", "I"]


### PR DESCRIPTION
- Activate sorting of imports in ruff
- Disable removing unused imports in __init__ modules