### PR TITLE
When a cell is not present in the notebook, do not try to render an AnnotationUI

### DIFF
--- a/e2xgrader/server_extensions/apps/formgrader/static/js/formgrade_models.js
+++ b/e2xgrader/server_extensions/apps/formgrader/static/js/formgrade_models.js
@@ -175,6 +175,12 @@ let Comments = Backbone.Collection.extend({
 
 let AnnotationUI = Backbone.View.extend({
   initialize: function () {
+    if (this.$el.length == 0) {
+      console.log(
+        "Failed to create AnnotationUI. Cell is not present in the notebook"
+      );
+      return;
+    }
     this.$switch = this.$el.find('input[name="annotate"]');
     this.$switch.prop("checked", "checked");
 


### PR DESCRIPTION
Sometimes students might submit notebooks where not all cells are present. Then the canvas for that cell can't be found and annotations do not work in the notebook.

