### PR TITLE
Open html version of submission in new tab

### DIFF
--- a/packages/exam-menubar/src/submit.js
+++ b/packages/exam-menubar/src/submit.js
@@ -156,10 +156,12 @@ export class Submit {
       body.append($("<pre/>").text(data["hashcode"]));
 
       body.append(
-        $("<p/>")
-          .append("You can verify your submission ")
-          .append($("<a/>").attr("href", hashcode_html).text("here"))
-          .append(".")
+        $("<h4/>").append(
+          $("<a/>")
+            .attr("href", hashcode_html)
+            .attr("target", "_blank")
+            .text("Click here to view the HTML version of your submitted exam.")
+        )
       );
     }
 


### PR DESCRIPTION
After submitting students can look at a HTML version of their submission.
The link is bigger and opens in a new tab.