### PR TITLE
Remove mathjax url

### DIFF
--- a/e2xgrader/server_extensions/apps/formgrader/handlers.py
+++ b/e2xgrader/server_extensions/apps/formgrader/handlers.py
@@ -214,7 +214,6 @@ class SubmissionHandler(BaseHandler):
             "index": ix,
             "total": len(indices),
             "base_url": self.base_url,
-            "my_mathjax_url": self.base_url + "/" + self.mathjax_url,
             "student": student_id,
             "last_name": submission.student.last_name,
             "first_name": submission.student.first_name,

--- a/e2xgrader/server_extensions/apps/formgrader/templates/formgrade/index.html.j2
+++ b/e2xgrader/server_extensions/apps/formgrader/templates/formgrade/index.html.j2
@@ -15,7 +15,7 @@
 
 
 <!-- Loading mathjax macro -->
-{{ mathjax( resources.my_mathjax_url + '?config=TeX-AMS-MML_HTMLorMML-full') }}
+{{ mathjax( ) }}
 
 <link rel="stylesheet" href="{{ resources.base_url }}/formgrader/static/css/formgrade.css" />
 <style type="text/css">


### PR DESCRIPTION
The mathjax config in formgrade mode caused broken URLs. The custom URL is removed now.