### PR TITLE
Fix name of original variable

### DIFF
--- a/packages/cells/src/utils/diagram-editor.js
+++ b/packages/cells/src/utils/diagram-editor.js
@@ -206,7 +206,7 @@ class DiagramEditor {
     if (this.frame != null) {
       this.frame.contentWindow.postMessage(
         JSON.stringify(msg),
-        this.drawOrigin
+        this.origin
       );
     }
   }


### PR DESCRIPTION
Diagram editor was referring to non existing variable `this.drawOrigin`. Changed to `this.origin`