### PR TITLE
Remove reference to non-existent variable views

### DIFF
--- a/e2xgrader/server_extensions/apps/formgrader/static/js/manage_assignments.js
+++ b/e2xgrader/server_extensions/apps/formgrader/static/js/manage_assignments.js
@@ -785,7 +785,6 @@ let loadAssignments = function () {
           model: model,
           el: insertRow(tbl),
         });
-        views.push(view);
       });
       insertDataTable(tbl.parent());
       models.loaded = true;


### PR DESCRIPTION
This bug caused not all assignments to be shown in the manage assignments tab