### PR TITLE
Replace this with that in create_header method

### DIFF
--- a/packages/assignment-view-celltoolbar/src/celltoolbar.js
+++ b/packages/assignment-view-celltoolbar/src/celltoolbar.js
@@ -129,8 +129,9 @@ export class AssignmentViewToolbar {
    */
   create_header(div, cell, celltoolbar) {
     if (cell.cell_type === null) {
+      let that = this;
       setTimeout(function () {
-        this.create_header(div, cell, celltoolbar);
+        that.create_header(div, cell, celltoolbar);
       }, 100);
     } else {
       if (!nbgrader_utils.is_solution(cell)) {


### PR DESCRIPTION
Fixes an issue in the `create_header` method by using `that` to preserve the correct context within the `setTimeout` callback.