### PR TITLE
Set notebook as dirty on cell change

### DIFF
--- a/packages/cells/src/cells/choice-cell.js
+++ b/packages/cells/src/cells/choice-cell.js
@@ -56,6 +56,7 @@ export class SinglechoiceCell extends ChoiceCell {
           choices.indexOf(i.toString()) >= 0,
           function () {
             that.set_choice(this.value);
+            Jupyter.notebook.set_dirty(true);
           }
         );
         Jupyter.keyboard_manager.register_events(input);
@@ -117,6 +118,7 @@ export class MultiplechoiceCell extends ChoiceCell {
         } else {
           that.remove_choice(this.value);
         }
+        Jupyter.notebook.set_dirty(true);
       });
     if (selected) {
       input.attr("checked", "checked");

--- a/packages/cells/src/utils/diagram-editor.js
+++ b/packages/cells/src/utils/diagram-editor.js
@@ -204,10 +204,7 @@ class DiagramEditor {
 
   postMessage(msg) {
     if (this.frame != null) {
-      this.frame.contentWindow.postMessage(
-        JSON.stringify(msg),
-        this.origin
-      );
+      this.frame.contentWindow.postMessage(JSON.stringify(msg), this.origin);
     }
   }
 
@@ -288,13 +285,16 @@ class DiagramEditor {
       this.initializeEditor();
     } else if (msg.event == "autosave") {
       this.save(msg.xml, true, this.startElement);
+      Jupyter.notebook.set_dirty(true);
     } else if (msg.event == "export") {
       this.cell.model.setAttachment("diagram.png", msg.data);
       this.setElementData(this.startElement, msg.data);
       this.stopEditing();
       this.xml = null;
+      Jupyter.notebook.set_dirty(true);
     } else if (msg.event == "save") {
       this.save(msg.xml, false, this.startElement);
+      Jupyter.notebook.set_dirty(true);
       this.xml = msg.xml;
 
       if (msg.exit) {


### PR DESCRIPTION
This pull request ensures that the notebook is marked as dirty whenever there are changes in the cells. Specifically, it sets the notebook as dirty when:

- Multiple choice answers are selected.
- Single choice answers are selected.
- Diagrams are changed.