### PR TITLE
Restrict exam notebook menus via css

### DIFF
--- a/packages/restricted-exam-notebook/src/exam-view.css
+++ b/packages/restricted-exam-notebook/src/exam-view.css
@@ -119,3 +119,32 @@
 #advanced:hover .dropdown {
   display: block;
 }
+
+#copy_notebook {
+  display: none;
+}
+
+li:has(> #download_menu) {
+    display: none;
+}
+
+
+li:has(> #widget-submenu) {
+    display: none;
+}
+
+#print_preview {
+  display: none;
+}
+
+#open_notebook {
+  display: none;
+}
+
+#new_notebook {
+  display: none;
+}
+
+#file_menu > .divider {
+  display: none;
+}


### PR DESCRIPTION
This pull request introduces several UI restrictions to the exam notebook interface by hiding various menu items and buttons through CSS changes. These adjustments help streamline the user experience and prevent access to certain features during restricted exam sessions.

**UI Restrictions:**

* The following elements are now hidden: `#copy_notebook`, `#download_menu` (and its parent `li`), `#widget-submenu` (and its parent `li`), `#print_preview`, `#open_notebook`, `#new_notebook`, and dividers inside `#file_menu`.