### PR TITLE
Feature/restricted exam file menu

### DIFF
--- a/packages/restricted-exam-notebook/src/exam-view.css
+++ b/packages/restricted-exam-notebook/src/exam-view.css
@@ -1,131 +1,15 @@
-:root {
-  --blue: #eaf4f7;
-  --blue-border: #dae4e7;
-  --blue-hover: #c4dde6;
-  --light-blue: #f8fbfc;
-  --orange: #f37726;
-  --orange-border: #f3631d;
-}
+/* Hide Help Menu, Edit Menu and Insert Menu */
 
-#e2xtoolbar {
-  display: block;
-
-  background-color: var(--blue);
-  line-height: 3em;
-
-  border: 1px solid var(--blue-border);
-}
-
-#e2xtoolbar a {
-  text-decoration: none;
-  color: black;
-}
-
-.toolbarbutton {
-  display: inline-block;
-  padding: 0 1em 0 1em;
-  border-right: 1px solid var(--blue-border);
-}
-
-#e2xtoolbar button,
-.e2xbutton {
-  display: inline-block;
-  padding: 0 1em 0 1em;
-  height: 3em;
-  border: none;
-  background-color: var(--blue);
-  cursor: pointer;
-}
-
-#e2xtoolbar button:hover,
-.e2xbutton:hover {
-  color: black;
-  background-color: var(--blue-hover);
-}
-
-#run_int {
-  border-left: 1px solid var(--blue-border);
-  border-right: 1px solid var(--blue-border);
-}
-
-#save-notbook i {
-  scale: 1.5;
-}
-
-#menubar-container {
-  margin-top: -1em;
-}
-
-#e2xtoolbar #submit {
-  float: right;
-  background-color: var(--orange);
-  border: 2px solid var(--orange-border);
-}
-
-#e2xtoolbar #submit i {
-  padding-left: 0.5em;
-}
-
-#e2xtoolbar #e2xhelp {
-  float: right;
-  border-left: 1px solid var(--blue-border);
-}
-
-#e2xhelp i {
-  padding-left: 0.5em;
-}
-
-#nb_name {
-  padding-left: 1em;
-  font-size: 1.5em;
-}
-
-#e2x_kernel_indicator {
-  padding: 1em;
-  border-right: 1px solid var(--blue-border);
-}
-
-#e2x_kernel_indicator #kernel_indicator_icon {
-  padding-left: 0.5em;
-}
-
-.dropdown {
-  position: absolute;
-  display: none;
-  list-style-type: none;
-  background-color: var(--light-blue);
-  text-decoration: none;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
-  padding: 0.5em 0 0.5em 0;
-  margin-left: -1em;
-  min-width: 9em;
-  border: 1px solid rgba(0, 0, 0, 0.15);
-}
-
-.dropdown > li:hover {
-  background-color: var(--blue);
-}
-
-.dropdown_item {
-  line-height: 2em;
-  padding: 0 0.5em 0 0.5em;
-}
-
-#advanced {
-  float: right;
-  border-left: 1px solid var(--blue-border);
-}
-
-#advanced:hover .dropdown {
-  display: block;
-}
-
-#copy_notebook {
-  display: none;
-}
-
-li:has(> #download_menu) {
+li:has(> #help_menu) {
     display: none;
+}
+
+li:has(> #edit_menu) {
+    display: none;
+}
+
+li:has(> #insert_menu) {
+  display: none;
 }
 
 
@@ -133,18 +17,38 @@ li:has(> #widget-submenu) {
     display: none;
 }
 
+/* View Menu */
+
+#toggle_toolbar {
+  display: none;
+}
+
+/* File Menu */
+
+li:has(> #download_menu) {
+    display: none;
+}
+
+#open_notebook, #new_notebook, #copy_notebook {
+  display: none;
+}
+
 #print_preview {
-  display: none;
-}
-
-#open_notebook {
-  display: none;
-}
-
-#new_notebook {
   display: none;
 }
 
 #file_menu > .divider {
   display: none;
 }
+
+/* Cell Menu */
+
+#cell_menu > .divider {
+  display: none;
+}
+
+#change_cell_type {
+  display: none;
+}
+
+

--- a/packages/restricted-exam-notebook/src/index.js
+++ b/packages/restricted-exam-notebook/src/index.js
@@ -1,1 +1,2 @@
+import "./exam-view.css";
 export { disable_shortcuts } from "./disable-shortcuts";

--- a/packages/restricted-exam-notebook/webpack.config.js
+++ b/packages/restricted-exam-notebook/webpack.config.js
@@ -16,6 +16,23 @@ module.exports = {
     /^notebook\/js*/,
   ],
   optimization: {
-    minimize: false,
+    minimize: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        include: path.resolve(__dirname, "src"),
+        loader: "babel-loader",
+        options: {
+          presets: ["@babel/preset-env"],
+          plugins: ["transform-class-properties"],
+        },
+      },
+      {
+        test: /\.css$/,
+        use: ["style-loader", "css-loader"],
+      },
+    ],
   },
 };


### PR DESCRIPTION
**Build System Improvements:**

* The Webpack configuration now enables JavaScript transpilation with Babel (including class properties), CSS loading, and output minimization for better compatibility and smaller bundles.
* The main entry point (`index.js`) now imports the exam view CSS, ensuring styles are applied when the package is used.

**Exam View and UI Changes:**

* The `exam-view.css` file has been refactored to remove all previous toolbar and button styles, replacing them with targeted CSS rules that hide specific menus and toolbar items (e.g., Help, Edit, Insert, Widget, and various file/cell menu options). This streamlines the exam interface and restricts user access to certain features.

In #196  the css was not correctly loaded.